### PR TITLE
Conversions blog post

### DIFF
--- a/blogs/Conversions.md
+++ b/blogs/Conversions.md
@@ -116,7 +116,7 @@ dynamic list = new List<string>();
 list.Add(default(int));
 </pre>
 
-Here's the code:
+Here's the code, much of which was cobbled together by using <a href="https://www.linqpad.net/">LinqPad</a> to examine the IL for the above dynamic code.
 
 <pre>
 public static bool IsImplicitlyCastableTo(this Type from, Type to)


### PR DESCRIPTION
This blog post discusses how to check if two .NET types can be converted between, a rabbit hole I found myself in while doing some work on my OData library. After posting this, I'd like to post it as an answer to several SO threads on the subject:

http://stackoverflow.com/questions/292437/determine-if-a-reflected-type-can-be-cast-to-another-reflected-type

http://stackoverflow.com/questions/2224266/how-to-tell-if-type-a-is-implicitly-convertible-to-type-b/2224421#2224421

http://stackoverflow.com/questions/7042314/can-i-check-if-a-variable-can-be-cast-to-a-specified-type
